### PR TITLE
Add plain text mode

### DIFF
--- a/py-segment
+++ b/py-segment
@@ -6,12 +6,21 @@ from loomchild.segmenter import LoomchildSegmenter
 
 parser = argparse.ArgumentParser()
 parser.add_argument('-l', '--lang', dest="lang", required=True, type=str, help="Language of the input")
+parser.add_argument('-t', '--text', action='store_true', default=False, help="Input and output are read/written in plain text")
 options = parser.parse_args()
 
 segmenter = LoomchildSegmenter(options.lang)
 
 for doc in sys.stdin:
-    content = base64.b64decode(doc.strip().replace("\t", " ")).decode('utf-8')
+    if options.text:
+        content = doc.strip()
+    else:
+        content = base64.b64decode(doc.strip().replace("\t", " ")).decode('utf-8')
+
     output_text = segmenter.get_document_segmentation(content)
     output_text = "\n".join(output_text)
-    print(base64.b64encode(output_text.encode("utf-8")).decode("utf-8"))
+
+    if options.text:
+        print(output_text)
+    else:
+        print(base64.b64encode(output_text.encode("utf-8")).decode("utf-8"))


### PR DESCRIPTION
This wrapper is useful for me in other scenarios than inside Bitextor. So I added an option to process plain text instead of the b64 encoded lines. Asking for your permission before merging it.